### PR TITLE
Added typing import to prevent NameErrors

### DIFF
--- a/anim_tools/tables.py
+++ b/anim_tools/tables.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import *
 
 from manimlib.utils.iterables import list_update
 


### PR DESCRIPTION
Just noticed there were type declarations now such as `Union` etc. So I thought I'd just add a simple `from typing import *` to prevent some errors.